### PR TITLE
feat/three event binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,9 +632,8 @@ To load a Texture you have 3 possibilities (service, pipe, directive)
   ```
 - use the loader pipe
   ```html
-  <th-MeshBasicMaterial [map]='"thetexture.jpg" | loadTexture'
-    ><th-MeshBasicMaterial></th-MeshBasicMaterial
-  ></th-MeshBasicMaterial>
+  <th-MeshBasicMaterial [map]='"thetexture.jpg" | loadTexture'>
+  </th-MeshBasicMaterial>
   ```
 - use the injected service
 
@@ -688,6 +687,50 @@ you can listen to it like this:
 
 [Events Example](https://demike.github.io/ngx-three/events-example)
 
+## three.js Events
+
+Every wrapper can be used to bind to three js events
+within an Angular template.
+For this purpose you can pass an object ( key = event name, value = callback) to the `threeEvents` input.
+You have to make shure that context of the callback functions get preserved.
+This can be done 
+- by means of using the [bind pipe](#bind-pipe)
+- or by using fat arrow function members instead of methods (see example below)
+
+component:
+```ts
+
+@Component({
+  // ...
+})
+export class TestComponent {
+  public onOrbitControlChange(evt: Event) {
+      // ...
+  }
+  public onOrbitControlEnd = (evt: Event) => {  // <-- preserves this context when used in template
+    // ...
+  }
+}
+
+```
+template:
+```html
+     <!-- 
+      binding to three.js events:
+        1) change: with bind directive for preserving this scope
+        2) end: using a fat arrow member function for preserving this scope
+      -->
+      <th-orbitControls
+        [threeEvents]="{
+          'change': onOrbitControlChange | bind : this,
+          'end': onOrbitControlEnd
+        }"></th-orbitControls>
+    
+    </th-perspectiveCamera>
+```
+
+
+
 # Utilitiy Pipes / Directives
 
 ngx-three provides some utility pipes that ease input assignments
@@ -728,6 +771,16 @@ and ensures that the clone call only happens once
 
 <th-light [objRef]="light | clone"></th-light>
 ```
+
+## bind pipe
+
+binds a function to an object by means of [Function.prototype.bind()](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+
+
+```html
+<th-orbitControls [threeEvents]="{ end: onOrbitEnd | bind: this }"></th-orbitControls>
+```
+
 
 ## Stats Directive
 

--- a/projects/ngx-three-demo/src/app/events-example/events-example.component.html
+++ b/projects/ngx-three-demo/src/app/events-example/events-example.component.html
@@ -2,6 +2,7 @@
   <th-scene>
     <th-ambientLight> </th-ambientLight>
 
+    <!-- binding  onUpdate and onLoad events-->
     <th-object3D
       loadGLTF
       [url]="assetPath"
@@ -15,11 +16,25 @@
     <th-gridHelper [args]="[10, 10]"></th-gridHelper>
     <th-pointLight [position]="[10, 10, 10]"></th-pointLight>
 
+ 
     <th-perspectiveCamera
-      [args]="[45, 2, 0.1, 100]"
-      [position]="[10, 10, 10]"
-      [lookAt]="[0, 0, 0]"
-    ></th-perspectiveCamera>
+        [args]="[45, 2, 0.1, 100]"
+        [position]="[10, 10, 10]"
+        [lookAt]="[0, 0, 0]"
+    >
+      <!-- 
+      binding to three.js events:
+        1) change: with bind directive for preserving this scope
+        2) end: with using a fat arrow member function for preserving this scope
+      -->
+      <th-orbitControls
+        [threeEvents]="{
+          'change': onOrbitControlChange | bind : this,
+          'end': onOrbitControlEnd
+        }"></th-orbitControls>
+    
+    </th-perspectiveCamera>
+    
   </th-scene>
 </th-canvas>
 

--- a/projects/ngx-three-demo/src/app/events-example/events-example.component.spec.ts
+++ b/projects/ngx-three-demo/src/app/events-example/events-example.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NgxThreeModule } from 'ngx-three';
 
 import { EventsExampleComponent } from './events-example.component';
 
@@ -8,6 +9,7 @@ describe('EventsExampleComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [NgxThreeModule],
       declarations: [EventsExampleComponent]
     }).compileComponents();
   });

--- a/projects/ngx-three-demo/src/app/events-example/events-example.component.ts
+++ b/projects/ngx-three-demo/src/app/events-example/events-example.component.ts
@@ -8,6 +8,7 @@ import { ASSET_PATH } from '../assets';
 
 })
 export class EventsExampleComponent {
+  public readonly id = 'CID';
   public changes: string[] = [];
   public rotation: [x: number, y: number, z: number] = [0, 0, 0];
   public position: [x: number, y: number, z: number] = [0, 1, 0];
@@ -25,13 +26,25 @@ export class EventsExampleComponent {
   }
 
   public logUpdates(changes: SimpleChanges) {
-    if (this.changes.length >= 20) {
-      this.changes.shift();
-    }
-    this.changes.push(Object.keys(changes).toString());
+    this.pushToChangesArray(Object.keys(changes).toString());
   }
 
   public onLoaded() {
     this.changes.push('Model loaded');
+  }
+
+  public onOrbitControlChange() {
+    this.pushToChangesArray(`${this.id}: orbit control change`);
+  }
+
+  public onOrbitControlEnd = () => { // <-- preserves binding scope when used in template
+    this.pushToChangesArray(`${this.id}: orbit control end`);
+  };
+
+  private pushToChangesArray(change: string) {
+    if (this.changes.length >= 20) {
+      this.changes.shift();
+    }
+    this.changes.push(change);
   }
 }

--- a/projects/ngx-three/src/lib/ThWrapperBase.ts
+++ b/projects/ngx-three/src/lib/ThWrapperBase.ts
@@ -46,6 +46,19 @@ export class ThWrapperBase<T, ARGS = unknown> implements ThWrapperLifeCycle, OnC
   @Input()
   public args?: ARGS;
 
+  protected eventListeners?: {[key: THREE.Event['type']]: THREE.EventListener<THREE.Event, THREE.Event['type'] , T> };
+  @Input()
+  public set threeEvents( eventMap: {[key: THREE.Event['type']]: THREE.EventListener<THREE.Event, THREE.Event['type'] , T> } | undefined) {
+    this.removeEvents();
+    this.eventListeners = eventMap;
+    this.applyEvents();
+  }
+
+  public get threeEvents() {
+    return this.eventListeners;
+  }
+
+
   @Output()
   public get onUpdate(): Observable<SimpleChanges> {
     if (!this.updateEmitter) {
@@ -117,6 +130,7 @@ export class ThWrapperBase<T, ARGS = unknown> implements ThWrapperLifeCycle, OnC
   }
 
   ngOnDestroy() {
+    this.removeEvents();
     this.removeFromParent();
 
     if (this.autoDispose) {
@@ -155,4 +169,22 @@ export class ThWrapperBase<T, ARGS = unknown> implements ThWrapperLifeCycle, OnC
       this.updateEmitter.next(changes);
     }
   }
+
+  private removeEvents() {
+    if( this.eventListeners && this._objRef) {
+      for(const entry of Object.entries(this.eventListeners)) {
+        (this._objRef as any).removeEventListener(entry[0],entry[1]);
+      }
+      this.eventListeners = undefined;
+    }
+  }
+
+  private applyEvents() {
+    if(this.eventListeners && this._objRef) {
+      for(const entry of Object.entries(this.eventListeners)) {
+        (this._objRef as any).addEventListener(entry[0],entry[1]);
+      }
+    }
+  }
+
 }

--- a/projects/ngx-three/src/lib/ngx-three.module.ts
+++ b/projects/ngx-three/src/lib/ngx-three.module.ts
@@ -27,6 +27,7 @@ import { ThWrapperBase } from './ThWrapperBase';
 import { ThFBXLoaderDirective, ThFBXLoaderPipe } from './loaders/ThFBXLoader';
 import { ThLogLuvLoaderDirective, ThLogLuvLoaderPipe } from './loaders/data-texture/ThLogLuvLoader';
 import { ThPLYLoaderDirective, ThPLYLoaderPipe } from './loaders/ThPLYLoader';
+import { BindPipe } from './pipes/bind.pipe';
 
 @NgModule({
   declarations: [
@@ -50,6 +51,7 @@ import { ThPLYLoaderDirective, ThPLYLoaderPipe } from './loaders/ThPLYLoader';
     Vector4Pipe,
     ClonePipe,
     FogPipe,
+    BindPipe,
     StatsDirective,
     ThRenderDirective,
     // texture loaders
@@ -98,6 +100,7 @@ import { ThPLYLoaderDirective, ThPLYLoaderPipe } from './loaders/ThPLYLoader';
     Vector4Pipe,
     ClonePipe,
     FogPipe,
+    BindPipe,
     ThRenderDirective,
     StatsDirective,
     // texture loaders

--- a/projects/ngx-three/src/lib/pipes/bind.pipe.spec.ts
+++ b/projects/ngx-three/src/lib/pipes/bind.pipe.spec.ts
@@ -1,0 +1,29 @@
+import { BindPipe } from './bind.pipe';
+
+class Test {
+  public member = 23;
+  public method() {
+    return this.member;
+  }
+}
+
+describe('Pipe: Bind', () => {
+  it('create an instance', () => {
+    const pipe = new BindPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should bind a method', () => {
+    const instance = new Test();
+    const pipe = new BindPipe();
+
+    const fn = instance.method;
+
+    // calling fn results in wrong this scope
+    expect(() => fn()).toThrow();
+
+    const boundFn = pipe.transform(instance.method, instance);
+    expect(boundFn()).toBe(instance.member);
+
+  });
+});

--- a/projects/ngx-three/src/lib/pipes/bind.pipe.ts
+++ b/projects/ngx-three/src/lib/pipes/bind.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'bind'
+})
+export class BindPipe implements PipeTransform {
+
+  transform(methodToBind: (...anyArgs: unknown[]) => unknown, instance: unknown) {
+    return methodToBind.bind(instance);
+  }
+
+}

--- a/projects/ngx-three/src/public-api.ts
+++ b/projects/ngx-three/src/public-api.ts
@@ -35,6 +35,7 @@ export * from './lib/pipes/clone.pipe';
 export * from './lib/pipes/color.pipe';
 export * from './lib/pipes/vector.pipe';
 export * from './lib/pipes/fog.pipe';
+export * from './lib/pipes/bind.pipe';
 
 export * from './lib/stats/stats.directive';
 


### PR DESCRIPTION
- allow binding to three.js events from within the Angular template
- add a bind pipe (like Function.prototype.bind() in the template)
- add a three.js binding example to the Events Example