### PR TITLE
feat: adds additional configuration options to DRACOLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,12 @@ i.e.:
 dracoLoader.setCrossOrigin('no-cors'); // just for testing (default: "anonymous")
 ```
 
+By default, a single DRACOLoader is reused when loading consecutive models.
+To change this behaviour, explicitly disable it:
+```ts
+dracoLoader.setReuseInstance(false); // (default: true)
+```
+
 You can find an example [here](https://demike.github.io/ngx-three/ref-by-id-example)
 
 ## Creating your own Loader

--- a/projects/ngx-three/src/lib/loaders/ThGLTFLoader.ts
+++ b/projects/ngx-three/src/lib/loaders/ThGLTFLoader.ts
@@ -1,4 +1,5 @@
 import { Directive, Host, Injectable, NgZone, Pipe, PipeTransform } from '@angular/core';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader';
 import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 import { ThObject3D } from '../generated/ThObject3D';
 import { DRACOLoaderService } from './compressed-texture/ThDRACOLoader';
@@ -9,15 +10,21 @@ import { ThAsyncLoaderBaseDirective, ThAsyncLoaderBasePipe, ThAsyncLoaderService
 })
 export class GLTFLoaderService extends ThAsyncLoaderService<GLTFLoader> {
   public clazz = GLTFLoader;
+  private dracoLoaderInstance: DRACOLoader | null = null;
 
   constructor(protected dracoLoaderService: DRACOLoaderService) {
     super();
   }
 
   public createLoaderInstance(): GLTFLoader {
-      const loader = super.createLoaderInstance();
-      loader.setDRACOLoader(this.dracoLoaderService.createLoaderInstance());
-      return loader;
+    const loader = super.createLoaderInstance();
+
+    if (!this.dracoLoaderInstance) {
+      this.dracoLoaderInstance = this.dracoLoaderService.createLoaderInstance();
+    }
+
+    loader.setDRACOLoader(this.dracoLoaderInstance);
+    return loader;
   }
 }
 

--- a/projects/ngx-three/src/lib/loaders/ThGLTFLoader.ts
+++ b/projects/ngx-three/src/lib/loaders/ThGLTFLoader.ts
@@ -1,5 +1,4 @@
 import { Directive, Host, Injectable, NgZone, Pipe, PipeTransform } from '@angular/core';
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader';
 import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 import { ThObject3D } from '../generated/ThObject3D';
 import { DRACOLoaderService } from './compressed-texture/ThDRACOLoader';
@@ -10,21 +9,15 @@ import { ThAsyncLoaderBaseDirective, ThAsyncLoaderBasePipe, ThAsyncLoaderService
 })
 export class GLTFLoaderService extends ThAsyncLoaderService<GLTFLoader> {
   public clazz = GLTFLoader;
-  private dracoLoaderInstance: DRACOLoader | null = null;
 
   constructor(protected dracoLoaderService: DRACOLoaderService) {
     super();
   }
 
   public createLoaderInstance(): GLTFLoader {
-    const loader = super.createLoaderInstance();
-
-    if (!this.dracoLoaderInstance) {
-      this.dracoLoaderInstance = this.dracoLoaderService.createLoaderInstance();
-    }
-
-    loader.setDRACOLoader(this.dracoLoaderInstance);
-    return loader;
+      const loader = super.createLoaderInstance();
+      loader.setDRACOLoader(this.dracoLoaderService.createLoaderInstance());
+      return loader;
   }
 }
 

--- a/projects/ngx-three/src/lib/loaders/compressed-texture/ThDRACOLoader.ts
+++ b/projects/ngx-three/src/lib/loaders/compressed-texture/ThDRACOLoader.ts
@@ -53,7 +53,7 @@ export interface DRACODecoderConfig {
       if (this.reuseInstance) {
         this.instance = loader;
       }
-      
+
       return loader;
     }
   }

--- a/projects/ngx-three/src/lib/loaders/compressed-texture/ThDRACOLoader.ts
+++ b/projects/ngx-three/src/lib/loaders/compressed-texture/ThDRACOLoader.ts
@@ -13,6 +13,9 @@ export interface DRACODecoderConfig {
     public readonly clazz = DRACOLoader;
     protected decoderPath = '';
     protected decoderConfig?: DRACODecoderConfig;
+    protected reuseInstance = true;
+
+    protected instance?: DRACOLoader;
 
     public setDecoderPath(path: string) {
       this.decoderPath = path;
@@ -22,12 +25,25 @@ export interface DRACODecoderConfig {
       this.decoderConfig = config;
     }
 
+    public setReuseInstance(reuse: boolean) {
+      this.reuseInstance = reuse;
+    }
+
     public createLoaderInstance(): DRACOLoader {
-        const loader = super.createLoaderInstance();
-        loader.setDecoderPath(this.decoderPath);
-        if(this.decoderConfig) {
+      if (this.reuseInstance && this.instance) {
+          return this.instance;
+      }
+
+      const loader = super.createLoaderInstance();
+      loader.setDecoderPath(this.decoderPath);
+      if(this.decoderConfig) {
         loader.setDecoderConfig(this.decoderConfig);
-        }
-        return loader;
+      }
+
+      if (this.reuseInstance) {
+        this.instance = loader;
+      }
+      
+      return loader;
     }
   }

--- a/projects/ngx-three/src/lib/loaders/compressed-texture/ThDRACOLoader.ts
+++ b/projects/ngx-three/src/lib/loaders/compressed-texture/ThDRACOLoader.ts
@@ -13,6 +13,7 @@ export interface DRACODecoderConfig {
     public readonly clazz = DRACOLoader;
     protected decoderPath = '';
     protected decoderConfig?: DRACODecoderConfig;
+    protected workerLimit?: number;
     protected reuseInstance = true;
 
     protected instance?: DRACOLoader;
@@ -23,6 +24,10 @@ export interface DRACODecoderConfig {
 
     public setDecoderConfig(config: DRACODecoderConfig) {
       this.decoderConfig = config;
+    }
+
+    public setWorkerLimit(limit: number) {
+      this.workerLimit = limit;
     }
 
     public setReuseInstance(reuse: boolean) {
@@ -36,8 +41,13 @@ export interface DRACODecoderConfig {
 
       const loader = super.createLoaderInstance();
       loader.setDecoderPath(this.decoderPath);
+
       if(this.decoderConfig) {
         loader.setDecoderConfig(this.decoderConfig);
+      }
+
+      if(this.workerLimit) {
+        loader.setWorkerLimit(this.workerLimit);
       }
 
       if (this.reuseInstance) {


### PR DESCRIPTION
three.js [docs](https://threejs.org/docs/#examples/en/loaders/DRACOLoader) suggest reusing  a single DRACOLoader instance, this PR does that

the options exposed in `ThDRACOLoader.ts` still work as expected