### PR TITLE
feat: webxr support

### DIFF
--- a/projects/ngx-three-demo/src/app/app-routing.module.ts
+++ b/projects/ngx-three-demo/src/app/app-routing.module.ts
@@ -20,6 +20,7 @@ import { PostProcessingExampleComponent } from './post-processing-example/post-p
 import { RefByIdExampleComponent } from './ref-by-id-example/ref-by-id-example.component';
 import { SimpleExampleComponent } from './simple-example/simple-example.component';
 import { ViewsExampleComponent } from './views-example/views-example.component';
+import { WebXRExampleComponent } from './webxr-example/webxr-example.component';
 
 export const EXAMPLE_ROUTES: (Route & {
   data: {
@@ -245,7 +246,19 @@ export const EXAMPLE_ROUTES: (Route & {
         'https://raw.githubusercontent.com/demike/ngx-three/main/projects/ngx-three-demo/src/app/outline-pass-events-example/outline-pass-events-example.component.scss',
       ]
     }
-  }
+  },
+  {
+    path: 'webxr-example',
+    data: {
+      title: 'WebXR Example',
+      exampleComponent: WebXRExampleComponent,
+      declarations: ['WebXRExampleComponent', 'Box'],
+      codeUrls: [
+        'https://raw.githubusercontent.com/NewYearNewPhil/ngx-three/main/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.html',
+        'https://raw.githubusercontent.com/NewYearNewPhil/ngx-three/main/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.ts'
+      ]
+    }
+  },
 ];
 
 EXAMPLE_ROUTES.forEach((route) => (route.component = ExamplePageComponent));

--- a/projects/ngx-three-demo/src/app/app.module.ts
+++ b/projects/ngx-three-demo/src/app/app.module.ts
@@ -39,6 +39,7 @@ import { OnDemandExampleComponent } from './on-demand-example/on-demand-example.
 import { RefByIdExampleComponent } from './ref-by-id-example/ref-by-id-example.component';
 import { HtmlExampleComponent } from './html-example/html-example.component';
 import { OutlinePassEventsExampleComponent } from './outline-pass-events-example/outline-pass-events-example.component';
+import { WebXRExampleComponent } from './webxr-example/webxr-example.component';
 
 @NgModule({
   declarations: [
@@ -69,7 +70,8 @@ import { OutlinePassEventsExampleComponent } from './outline-pass-events-example
     OnDemandExampleComponent,
     RefByIdExampleComponent,
     HtmlExampleComponent,
-    OutlinePassEventsExampleComponent
+    OutlinePassEventsExampleComponent,
+    WebXRExampleComponent
   ],
   imports: [
     BrowserModule,

--- a/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.html
+++ b/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.html
@@ -1,0 +1,24 @@
+<button mat-raised-button 
+  [disabled]="!vrSupported"
+  (click)="enterWebXR('immersive-vr')">
+  {{vrSupported ? 'Start VR' : 'VR not supported'}}
+</button>
+<button mat-raised-button 
+  [disabled]="!arSupported"
+  (click)="enterWebXR('immersive-ar')">
+  {{arSupported ? 'Start AR' : 'AR not supported'}}
+</button>
+
+<th-canvas (onRender)="this.onBeforeRender()">
+  <th-view>
+    <th-scene>
+      <th-ambientLight />
+      <th-box (onClick)="selected = !selected" [position]="[0, 0, 0]" [material]="material" [rotation]="rotation"
+        [scale]="selected ? [2, 2, 2] : [1, 1, 1]" />
+  
+      <th-pointLight [position]="[10, 10, 10]" />
+  
+      <th-perspectiveCamera [args]="[45, 2, 0.1, 100]" [position]="[10, 10, 10]" [lookAt]="[0, 0, 0]" />
+    </th-scene>
+  </th-view>
+</th-canvas>

--- a/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.spec.ts
+++ b/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WebXRExampleComponent } from './webxr-example.component';
+
+describe('WebXRExampleComponent', () => {
+  let component: WebXRExampleComponent;
+  let fixture: ComponentFixture<WebXRExampleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [WebXRExampleComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WebXRExampleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.ts
+++ b/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.ts
@@ -1,0 +1,92 @@
+import { AfterViewInit, ChangeDetectionStrategy, Component, OnInit, SkipSelf, ViewChild } from '@angular/core';
+import { ThCanvas, ThView, createObj3DProviderArray } from 'ngx-three';
+import { ThMesh } from 'ngx-three';
+import { ThObject3D } from 'ngx-three';
+import * as THREE from 'three';
+import { BoxGeometry, MeshStandardMaterial } from 'three';
+
+@Component({
+  template: '',
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'th-box',
+  providers: createObj3DProviderArray(Box),
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+// eslint-disable-next-line @angular-eslint/component-class-suffix
+export class Box extends ThMesh implements OnInit {
+  constructor(@SkipSelf() parent: ThObject3D) {
+    super(parent);
+  }
+  public ngOnInit() {
+    super.ngOnInit();
+    if (this.objRef) {
+      this.objRef.material = new MeshStandardMaterial({
+        color: 'green'
+      });
+
+      this.objRef.geometry = new BoxGeometry(1, 1, 1);
+    }
+  }
+}
+
+@Component({
+  selector: 'app-webxr-example',
+  templateUrl: './webxr-example.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WebXRExampleComponent implements AfterViewInit {
+  @ViewChild(ThCanvas, { static: true }) 
+  canvas?: ThCanvas;
+
+  @ViewChild(ThView, { static: true }) 
+  view?: ThView;
+
+  public arSupported = false;
+  public vrSupported = false;
+
+  constructor() {
+    this.material.color.set('green');
+
+    setInterval(() => {
+      if (this.material.color.r !== 0) {
+        this.material = new THREE.MeshStandardMaterial();
+
+        this.material.color.set('green');
+      } else {
+        this.material = new THREE.MeshStandardMaterial();
+        this.material.color.set('red');
+      }
+    }, 200);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public THREE = THREE;
+
+  public box = new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1.5, 1.5, 1.5));
+  public color = new THREE.Color(1, 0, 0);
+
+  public rotation: [x: number, y: number, z: number] = [0, 0, 0];
+
+  public material = new THREE.MeshStandardMaterial();
+
+  public selected = false;
+
+  public onBeforeRender() {
+    this.rotation = [0, this.rotation[2] + 0.01, this.rotation[2] + 0.01];
+  }
+
+  ngAfterViewInit(): void {
+    this.view?.supportsWebXR('immersive-vr').then((supported) => {
+      this.vrSupported = supported;
+    });
+    this.view?.supportsWebXR('immersive-ar').then((supported) => {
+      this.arSupported = supported;
+    });
+  }
+
+  public enterWebXR(sessionMode: XRSessionMode): void {
+    if(this.view){
+      this.view.enterWebXR(sessionMode);
+    }
+  }
+}

--- a/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.ts
+++ b/projects/ngx-three-demo/src/app/webxr-example/webxr-example.component.ts
@@ -35,10 +35,10 @@ export class Box extends ThMesh implements OnInit {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WebXRExampleComponent implements AfterViewInit {
-  @ViewChild(ThCanvas, { static: true }) 
+  @ViewChild(ThCanvas, { static: true })
   canvas?: ThCanvas;
 
-  @ViewChild(ThView, { static: true }) 
+  @ViewChild(ThView, { static: true })
   view?: ThView;
 
   public arSupported = false;

--- a/projects/ngx-three/src/lib/ThEngine.service.ts
+++ b/projects/ngx-three/src/lib/ThEngine.service.ts
@@ -33,6 +33,11 @@ export class ThEngineService implements OnDestroy {
   private readonly beforeRenderEmitter = new EventEmitter<RenderState>();
   private views: ThView[] = [];
 
+  //xr stuff
+  private xrSession?: XRSession;
+  private xrView?: ThView;
+  private xrInitialCamera?: THREE.Camera;
+
   public get canvas(): HTMLCanvasElement | undefined {
     return this.rendererParameters?.domElement;
   }
@@ -102,8 +107,12 @@ export class ThEngineService implements OnDestroy {
 
   public render(): void {
     this.beforeRenderEmitter.emit({engine: this, delta: this.clock.getDelta()});
-    for (const view of this.views) {
-      this.renderView(view);
+    if(!this.xrSession){
+      for (const view of this.views) {
+        this.renderView(view);
+      }
+    } else if (this.xrView){
+      this.renderView(this.xrView);
     }
   }
 
@@ -132,10 +141,10 @@ export class ThEngineService implements OnDestroy {
     }
 
     this.applyRendererParametersFromView(view);
-    if (view.effectComposer) {
-      view.effectComposer.render();
-    } else {
+    if(this.xrSession || !view.effectComposer){
       this._renderer.render(scene.objRef, camera.objRef);
+    } else {
+      view.effectComposer.render();
     }
   }
 
@@ -192,6 +201,58 @@ export class ThEngineService implements OnDestroy {
     this.resizeEmitter.emit({ width, height });
 
     return true;
+  }
+
+  public async enterWebXR(sessionMode: XRSessionMode, view: ThView): Promise<void>{
+    if(await this.supportsWebXR(sessionMode)){
+      this.xrView = view;
+      this.xrInitialCamera = view.camera?.objRef?.clone();
+
+      navigator.xr!.requestSession(sessionMode).then(this.onWebXRSessionStarted.bind(this));
+    } else {
+      console.warn(`requested WebXR session not supported: "${sessionMode}"`);
+    }
+  }
+
+  public exitWebXR(): void{
+    if(this.xrSession){
+      this.xrSession.end();
+    }
+  }
+
+  public async supportsWebXR(sessionMode: XRSessionMode): Promise<boolean> {
+    return 'xr' in navigator && await navigator.xr!.isSessionSupported(sessionMode);
+  }
+
+  private async onWebXRSessionStarted(session: XRSession): Promise<void> {
+    if(!this._renderer) {
+      return;
+    }
+
+    session.addEventListener('end', this.onWebXRSessionEnded.bind(this));
+    this._renderer!.xr.setReferenceSpaceType('local');
+    this._renderer.xr.enabled = true;
+    this._renderer.xr.setSession(session);
+
+    this._renderer.setAnimationLoop(this.render.bind(this));
+
+    this.xrSession = session;
+  }
+
+  private async onWebXRSessionEnded(): Promise<void> {
+    if(!this.xrSession || !this.xrView) {
+      return;
+    }
+
+    this.xrSession.removeEventListener('end', this.onWebXRSessionEnded.bind(this));
+    this.xrSession = undefined;
+
+    if(this.xrView.camera && this.xrInitialCamera){
+      this.xrView.camera.objRef?.copy(this.xrInitialCamera);
+    }
+
+    this.xrInitialCamera = undefined;
+    this.xrView = undefined;
   }
 
   protected calcRendererSize() {

--- a/projects/ngx-three/src/lib/ThEngine.service.ts
+++ b/projects/ngx-three/src/lib/ThEngine.service.ts
@@ -203,12 +203,12 @@ export class ThEngineService implements OnDestroy {
     return true;
   }
 
-  public async enterWebXR(sessionMode: XRSessionMode, view: ThView): Promise<void>{
-    if(await this.supportsWebXR(sessionMode)){
+  public async enterWebXR(sessionMode: XRSessionMode, view: ThView, sessionInit?: XRSessionInit): Promise<void>{
+    if(await this.supportsWebXR(sessionMode) && navigator.xr){
       this.xrView = view;
       this.xrInitialCamera = view.camera?.objRef?.clone();
 
-      navigator.xr!.requestSession(sessionMode).then(this.onWebXRSessionStarted.bind(this));
+      navigator.xr.requestSession(sessionMode, sessionInit).then(this.onWebXRSessionStarted.bind(this));
     } else {
       console.warn(`requested WebXR session not supported: "${sessionMode}"`);
     }
@@ -221,16 +221,16 @@ export class ThEngineService implements OnDestroy {
   }
 
   public async supportsWebXR(sessionMode: XRSessionMode): Promise<boolean> {
-    return 'xr' in navigator && await navigator.xr!.isSessionSupported(sessionMode);
+    return navigator.xr && await navigator.xr.isSessionSupported(sessionMode) ? true : false;
   }
 
   private async onWebXRSessionStarted(session: XRSession): Promise<void> {
-    if(!this._renderer) {
+    if(!this._renderer || !this._renderer.xr) {
       return;
     }
 
     session.addEventListener('end', this.onWebXRSessionEnded.bind(this));
-    this._renderer!.xr.setReferenceSpaceType('local');
+    this._renderer.xr.setReferenceSpaceType('local');
     this._renderer.xr.enabled = true;
     this._renderer.xr.setSession(session);
 

--- a/projects/ngx-three/src/lib/ThView.ts
+++ b/projects/ngx-three/src/lib/ThView.ts
@@ -111,8 +111,8 @@ export class ThView implements OnInit {
     camera: ThCamera;
   }>();
 
-  public enterWebXR(sessionMode: XRSessionMode){
-    this.engServ.enterWebXR(sessionMode, this);
+  public enterWebXR(sessionMode: XRSessionMode, sessionInit?: XRSessionInit){
+    this.engServ.enterWebXR(sessionMode, this, sessionInit);
   }
 
   public exitWebXR(){

--- a/projects/ngx-three/src/lib/ThView.ts
+++ b/projects/ngx-three/src/lib/ThView.ts
@@ -111,6 +111,18 @@ export class ThView implements OnInit {
     camera: ThCamera;
   }>();
 
+  public enterWebXR(sessionMode: XRSessionMode){
+    this.engServ.enterWebXR(sessionMode, this);
+  }
+
+  public exitWebXR(){
+    this.engServ.exitWebXR();
+  }
+
+  public async supportsWebXR(sessionMode: XRSessionMode): Promise<boolean>{
+    return this.engServ.supportsWebXR(sessionMode);
+  }
+
   ngOnInit(): void {
     this.initRaycaster();
   }


### PR DESCRIPTION
I'm experimenting with integrating augmented / virtual reality experiences to my app and have managed to add basic support for it to ngx-three, but very likely not in a way that's very useful for others.

I'm leaving this here as a draft PR to see if there's interest in this feature. To actually integrate it upstream, I would require some guidance from you @demike on what is a suitable approach for it.

For now, the integration happens in `ThEngineService` and `ThView`, the effect feature of the library is circumvented when in XR mode. It also doesn't use the `requestAnimationFrame` logic as that's not compatible with WebXR.

I've added an example for testing this feature as `WebXR example`.
AR is best be tested on an up to date Chrome Browser on Android, for VR there's a [browser extension](https://github.com/MozillaReality/WebXR-emulator-extension) to emulate it.