### PR TITLE
Fix rendererParamaters type

### DIFF
--- a/projects/ngx-three-demo/src/app/animation-example/animation-example.component.html
+++ b/projects/ngx-three-demo/src/app/animation-example/animation-example.component.html
@@ -1,4 +1,4 @@
-<th-canvas *rendererParameters="{ outputEncoding }"  (onRender)="this.onBeforeRender()" [thStats]="true" [shadow]="true" >
+<th-canvas (onRender)="this.onBeforeRender()" [thStats]="true" [shadow]="true">
   <th-scene [background]="['#e0e0e0']" [fog]="['#e0e0e0', 20, 100] | fog" >
       <th-perspectiveCamera
         [args]="[45, 2, 0.25, 100]"

--- a/projects/ngx-three-demo/src/app/animation-example/animation-example.component.ts
+++ b/projects/ngx-three-demo/src/app/animation-example/animation-example.component.ts
@@ -5,7 +5,7 @@ import { Material, sRGBEncoding, TextureEncoding } from 'three';
 @Component({
   selector: 'app-animation-example',
   templateUrl: './animation-example.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AnimationExampleComponent implements AfterViewInit {
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/projects/ngx-three/src/lib/renderer/renderer-providers.ts
+++ b/projects/ngx-three/src/lib/renderer/renderer-providers.ts
@@ -22,7 +22,7 @@ const RENDERER_DEFAULTS: WebGLRendererParameters = {
   preserveDrawingBuffer: true,
 };
 
-export type ThRendererParameters = Partial<WebGLRenderer>;
+export type ThRendererParameters = Partial<WebGLRendererParameters>;
 
 export const RENDERER_PROVIDERS = new InjectionToken<Renderer[]>('Renderer Providers');
 export const CSS3D_RENDERER = new InjectionToken<CSS3DRenderer>('CSS3DRenderer');


### PR DESCRIPTION
Hi!

Should the `renderParameters` input type be a a Partial of `WebGLRendererParameters` instead of the entire `WebGLRenderer` class?

- AnyFinCanHappen